### PR TITLE
Ensure APK exists and fix release asset naming in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,10 @@ jobs:
     - name: Build Android (APK)
       run: flutter build apk --release
 
+    - name: Verify Android APK exists
+      run: |
+        test -f build/app/outputs/apk/release/app-release.apk || { echo "APK not found. Check Flutter build output path."; exit 1; }
+
     # - name: Build iOS (IPA)
     #   run: flutter build ipa --no-codesign
 
@@ -71,7 +75,10 @@ jobs:
         tag_name: latest
         files: |
           web_build.zip
-          build/app/outputs/apk/release/app-release.apk#ITM-Connect.apk
+          build/app/outputs/apk/release/app-release.apk
+        name: |
+          web_build.zip
+          ITM-Connect.apk
         overwrite: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -96,7 +103,9 @@ jobs:
       with:
         tag_name: v${{ steps.vars.outputs.version }}
         files: |
-          build/app/outputs/apk/release/app-release.apk#ITM-Connect.apk
+          build/app/outputs/apk/release/app-release.apk
+        name: |
+          ITM-Connect.apk
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
- Add step to verify the Android APK is produced before upload
- Remove inline rename in files path; use explicit asset `name` fields
- Clarify asset names for latest and versioned releases to avoid upload issues