### PR TITLE
Normalize release workflow file formatting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,3 +121,4 @@ jobs:
     #       build/ios/ipa/runner.ipa#runner.ipa
     #   env:
     #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
Add a trailing newline to .github/workflows/release.yml to conform to POSIX/editor conventions and avoid tooling diffs or lint warnings.