### PR TITLE
Standardize release asset names to lowercase apk

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
         overwrite: true
         asset_name: |
           ITM-Connect-Web.zip
-          ITM-Connect.apk
+          itm-connect.apk
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -109,7 +109,7 @@ jobs:
           build/app/outputs/apk/release/app-release.apk
         file_glob: false
         overwrite: true
-        asset_name: ITM-Connect-v${{ steps.vars.outputs.version }}.apk
+        asset_name: itm-connect-v${{ steps.vars.outputs.version }}.apk
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -121,4 +121,3 @@ jobs:
     #       build/ios/ipa/runner.ipa#runner.ipa
     #   env:
     #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-


### PR DESCRIPTION
Update GitHub Actions release workflow to use lowercase APK asset names (`itm-connect.apk` and `itm-connect-v<version>.apk`) for consistency and to avoid case-sensitivity issues across platforms. Remove trailing blank line.