### PR TITLE
Rename APK artifact and upload name in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
     - name: Verify Android APK exists
       run: |
         test -f build/app/outputs/apk/release/app-release.apk || { echo "APK not found. Check Flutter build output path."; exit 1; }
+        cp build/app/outputs/apk/release/app-release.apk build/app/outputs/apk/release/itm-connect.apk
 
     # - name: Build iOS (IPA)
     #   run: flutter build ipa --no-codesign
@@ -75,12 +76,12 @@ jobs:
         tag_name: latest
         files: |
           web_build.zip
-          build/app/outputs/apk/release/app-release.apk
+          build/app/outputs/apk/release/itm-connect.apk
         file_glob: false
         overwrite: true
         asset_name: |
           ITM-Connect-Web.zip
-          itm-connect.apk
+          ITM-Connect.apk
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -106,10 +107,10 @@ jobs:
       with:
         tag_name: v${{ steps.vars.outputs.version }}
         files: |
-          build/app/outputs/apk/release/app-release.apk
+          build/app/outputs/apk/release/itm-connect.apk
         file_glob: false
         overwrite: true
-        asset_name: itm-connect-v${{ steps.vars.outputs.version }}.apk
+        asset_name: ITM-Connect-v${{ steps.vars.outputs.version }}.apk
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
- Copy app-release.apk to itm-connect.apk during build to standardize artifact name
- Update release assets to use itm-connect.apk and capitalize "ITM-Connect" for consistency across latest and versioned releases